### PR TITLE
Fixed nvs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ git clone git://github.com/nodejs/abi-stable-node.git --branch 8.x_napi_0.1.0
 To execute the N-API-enabled module code, you will also need to run the demo app with a version of Node.js which supports N-API. The simplest way to get this running is via NVS (https://github.com/jasongin/nvs). Sample commands to switch to a version of Node.js supporting N-API:
 
 ```
-nvs remote napi-node8-v8 https://github.com/nodejs/abi-stable-node/releases/#node-v6.*-v8
+nvs remote napi-node8-v8 https://github.com/nodejs/abi-stable-node/releases/#node-v8.*-v8
 nvs add napi-node8-v8
 nvs use napi-node8-v8
 ```


### PR DESCRIPTION
It was creating a remote called 'napi-node8-v8' but pointing to #node-v6.*-v8